### PR TITLE
Add basic web implementation

### DIFF
--- a/dist/docs.json
+++ b/dist/docs.json
@@ -7,7 +7,7 @@
     "methods": [
       {
         "name": "getManaged",
-        "signature": "(options: { key: string; }) => Promise<{ value: string; }>",
+        "signature": "(options: { key: string; }) => Promise<{ value: string | null; }>",
         "parameters": [
           {
             "name": "options",
@@ -15,7 +15,7 @@
             "type": "{ key: string; }"
           }
         ],
-        "returns": "Promise<{ value: string; }>",
+        "returns": "Promise<{ value: string | null; }>",
         "tags": [
           {
             "name": "since",

--- a/dist/esm/definitions.d.ts
+++ b/dist/esm/definitions.d.ts
@@ -7,6 +7,6 @@ export interface ManagedStoragePlugin {
     getManaged(options: {
         key: string;
     }): Promise<{
-        value: string;
+        value: string | null;
     }>;
 }

--- a/dist/esm/web.d.ts
+++ b/dist/esm/web.d.ts
@@ -4,6 +4,7 @@ export declare class ManagedStorageWeb extends WebPlugin implements ManagedStora
     getManaged(options: {
         key: string;
     }): Promise<{
-        value: string;
+        value: string | null;
     }>;
+    private get impl();
 }

--- a/dist/esm/web.js
+++ b/dist/esm/web.js
@@ -1,8 +1,11 @@
 import { WebPlugin } from '@capacitor/core';
 export class ManagedStorageWeb extends WebPlugin {
     async getManaged(options) {
-        console.log('No Web Implementation, Sorry', options);
-        return { value: options.key };
+        const value = this.impl.getItem(options.key);
+        return { value };
+    }
+    get impl() {
+        return window.localStorage;
     }
 }
 //# sourceMappingURL=web.js.map

--- a/dist/plugin.cjs.js
+++ b/dist/plugin.cjs.js
@@ -10,8 +10,11 @@ const ManagedStorage = core.registerPlugin('ManagedStorage', {
 
 class ManagedStorageWeb extends core.WebPlugin {
     async getManaged(options) {
-        console.log('No Web Implementation, Sorry', options);
-        return { value: options.key };
+        const value = this.impl.getItem(options.key);
+        return { value };
+    }
+    get impl() {
+        return window.localStorage;
     }
 }
 

--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -7,8 +7,11 @@ var capacitorManagedStorage = (function (exports, core) {
 
     class ManagedStorageWeb extends core.WebPlugin {
         async getManaged(options) {
-            console.log('No Web Implementation, Sorry', options);
-            return { value: options.key };
+            const value = this.impl.getItem(options.key);
+            return { value };
+        }
+        get impl() {
+            return window.localStorage;
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managed-defaults",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Provides iOS functionality for getting individual keys within the com.apple.configuration.managed Dictionary, as passed to an app by an MDM.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,5 +4,5 @@ export interface ManagedStoragePlugin {
    *
    * @since 0.0.1
    */
-  getManaged(options: { key: string }): Promise<{ value: string }>;
+  getManaged(options: { key: string }): Promise<{ value: string | null }>;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -5,8 +5,13 @@ import type { ManagedStoragePlugin } from './definitions';
 export class ManagedStorageWeb
   extends WebPlugin
   implements ManagedStoragePlugin {
-  async getManaged(options: { key: string }): Promise<{ value: string }> {
-    console.log('No Web Implementation, Sorry', options);
-    return { value: options.key };
+  public async getManaged(options: {
+    key: string;
+  }): Promise<{ value: string | null }> {
+    const value = this.impl.getItem(options.key);
+    return { value };
+  }
+  private get impl(): Storage {
+    return window.localStorage;
   }
 }


### PR DESCRIPTION
Update provides web implementation using LocalStorage.

MDM system passes default of type string with key: ```default_passed_by_mdm```

iOS value is pulled:
<img width="806" alt="Screen Shot 2021-10-17 at 21 47 57" src="https://user-images.githubusercontent.com/12582998/137644428-bbf81aa0-3a86-46bb-8755-4ff7067e5f89.png">

Web value is pulled for debugging purposes. Plugin grabs LocalStorage item matching the key requested. This does not append `com.apple.configuration.managed`. 

<img width="633" alt="Screen Shot 2021-10-17 at 21 55 08" src="https://user-images.githubusercontent.com/12582998/137644694-bf48a774-d2f8-46ce-8ebe-285ecb784808.png">

Example usage:
```
this.storageGetManagedObject('default_passed_by_mdm').then(
      (managed_default: ManagedDefault) => {
        if (managed_default !== null) {
          this.default.next(managed_default);
        }
      }
    );

async storageGetManagedObject(key: string) {
    const ret = await ManagedStorage.getManaged({ key });
    return JSON.parse(ret.value);
  }
```
